### PR TITLE
Add feed-parsing API endpoint

### DIFF
--- a/feedparser.js
+++ b/feedparser.js
@@ -1,0 +1,61 @@
+// Adapted from https://github.com/danmactough/node-feedparser#usage
+
+const request = require("request");
+const FeedParser = require("feedparser");
+
+exports.parse = requestedFeed =>
+  new Promise((resolve, reject) => {
+    let feedResponse = {};
+    let feedItems = [];
+
+    // Set up the request for the feed.
+    const feedRequest = request(requestedFeed);
+
+    // We're not setting options because the defaults are fine.
+    const options = [];
+    const feedparser = new FeedParser([options]);
+
+    feedRequest.on("error", function(error) {
+      // Reject the Promise by returning an error, with the origin
+      // of the error set to the request.
+      reject({ error: error, origin: "request" });
+    });
+
+    feedRequest.on("response", function(response) {
+      if (response.statusCode !== 200) {
+        // If we didn't get a 200 OK, emit an error.
+        feedRequest.emit("error", new Error("Bad status code: " + response.statusCode));
+      } else {
+        // Otherwise, pipe the request into feedparser.
+        feedRequest.pipe(feedparser);
+      }
+    });
+  
+    feedparser.on("error", function(error) {
+      // Reject the Promise by returning an error, with the origin
+      // of the error set to feedparser.
+      reject({ error: error, origin: "feedparser" });
+    });
+
+    feedparser.on("meta", function(meta) {
+      // When the meta event is received, add it as a property on feedResponse.
+      feedResponse.meta = meta;
+    });
+
+    feedparser.on("readable", function() {
+      var stream = this,
+        item;
+
+      while ((item = stream.read())) {
+        // Push each item in the feed into the feedItems array.
+        feedItems.push(item);
+      }
+    });
+
+    feedparser.on("end", function() {
+      // Add the feedItems array as a property on feedResponse.
+      feedResponse.items = feedItems;
+      // Resolve the Promise and return the feedResponse object.
+      resolve(feedResponse);
+    });
+  });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "express": "^4.17.1",
-    "sqlite3": "^4.1.1"
+    "sqlite3": "^4.1.1",
+    "feedparser": "^2.2.9"
   },
   "engines": {
     "node": "12.x"

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@
 // init project
 const express = require("express");
 const bodyParser = require("body-parser");
+const feedparser = require("./feedparser");
 const app = express();
 const fs = require("fs");
 app.use(bodyParser.urlencoded({ extended: true }));
@@ -48,6 +49,21 @@ db.serialize(() => {
 // http://expressjs.com/en/starter/basic-routing.html
 app.get("/", (request, response) => {
   response.sendFile(`${__dirname}/views/index.html`);
+});
+
+// API endpoint to parse an RSS/Atom feed.
+app.get("/api/parse/:feed", async function(request, response) {
+  // Try to parse the feed, and return the result to the API client.
+  feedparser
+    .parse(request.params.feed)
+    .then(data => {
+      // Success! Return the result to the API client.
+      response.send(data);
+    })
+    .catch(error => {
+      // Oh no! Return the error to the API client.
+      response.send(error);
+    });
 });
 
 // endpoint to get all the dreams in the database

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -1,5 +1,6 @@
 dependencies:
   express: 4.17.1
+  feedparser: 2.2.9
   sqlite3: 4.1.1
 packages:
   /abbrev/1.1.1:
@@ -15,6 +16,10 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
+  /addressparser/1.0.1:
+    dev: false
+    resolution:
+      integrity: sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y=
   /ajv/6.10.2:
     dependencies:
       fast-deep-equal: 2.0.1
@@ -51,6 +56,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+  /array-indexofobject/0.0.1:
+    dev: false
+    resolution:
+      integrity: sha1-qqEo5iybPDWAlFaMIZ/2T+SJ1Co=
   /asn1/0.2.4:
     dependencies:
       safer-buffer: 2.1.2
@@ -314,6 +323,23 @@ packages:
     dev: false
     resolution:
       integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+  /feedparser/2.2.9:
+    dependencies:
+      addressparser: 1.0.1
+      array-indexofobject: 0.0.1
+      lodash.assign: 4.2.0
+      lodash.get: 4.4.2
+      lodash.has: 4.5.2
+      lodash.uniq: 4.5.0
+      mri: 1.1.5
+      readable-stream: 2.3.7
+      sax: 1.2.4
+    dev: false
+    engines:
+      node: '>= 4.2.0'
+    hasBin: true
+    resolution:
+      integrity: sha1-kTgZfa/a4F/K3eADa+6vYGbCxek=
   /finalhandler/1.1.2:
     dependencies:
       debug: 2.6.9
@@ -540,6 +566,22 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
+  /lodash.assign/4.2.0:
+    dev: false
+    resolution:
+      integrity: sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
+  /lodash.get/4.4.2:
+    dev: false
+    resolution:
+      integrity: sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+  /lodash.has/4.5.2:
+    dev: false
+    resolution:
+      integrity: sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
+  /lodash.uniq/4.5.0:
+    dev: false
+    resolution:
+      integrity: sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
   /media-typer/0.3.0:
     dev: false
     engines:
@@ -611,6 +653,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  /mri/1.1.5:
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-d2RKzMD4JNyHMbnbWnznPaa8vbdlq/4pNZ3IgdaGrVbBhebBsGUUE/6qorTMYNS6TwuH3ilfOlD2bf4Igh8CKg==
   /ms/2.0.0:
     dev: false
     resolution:
@@ -1128,4 +1176,5 @@ shrinkwrapMinorVersion: 9
 shrinkwrapVersion: 3
 specifiers:
   express: ^4.17.1
+  feedparser: ^2.2.9
   sqlite3: ^4.1.1


### PR DESCRIPTION
This PR adds a `/api/parse/:feed` endpoint in **server.js** which uses **feedparser.js** to parse an RSS/Atom feed and returns a `feedResponse` object to the API client.