### PR TITLE
Add OPML file parsing

### DIFF
--- a/opmlparser.js
+++ b/opmlparser.js
@@ -6,7 +6,6 @@ const request = require("request");
 exports.getFeedsFromOPML = () =>
   new Promise((resolve, reject) => {
     const opmlparser = new OpmlParser()
-    let counter = 0;
     let feedUrls = [];
 
     var opmlRequest = request(`https://${process.env.PROJECT_DOMAIN}.glitch.me/subscriptions.opml`);
@@ -30,16 +29,21 @@ exports.getFeedsFromOPML = () =>
       reject({ error: error });
     });
   
+    // If we get a `readable` event, then...
     opmlparser.on("readable", function () {
       let outline;
 
+      // ...so long as there's an outline item
+      // available to read.. 
       while (outline = this.read()) {
         if (outline['#type'] === "feed") {
-          counter++;
+          // ...add its feed URL to the `feedUrls` array.
           feedUrls.push(outline.xmlurl);
         }
       }
     });
+  
+    // When we're done, resolve the Promise and send back the `feedUrls` object.
     opmlparser.on("end", function () {
       resolve(feedUrls);
     });

--- a/opmlparser.js
+++ b/opmlparser.js
@@ -1,0 +1,46 @@
+// Adapted from https://github.com/danmactough/node-opmlparser/blob/master/examples/simple.js
+
+const OpmlParser = require("opmlparser");
+const request = require("request");
+
+exports.getFeedsFromOPML = () =>
+  new Promise((resolve, reject) => {
+    const opmlparser = new OpmlParser()
+    let counter = 0;
+    let feedUrls = [];
+
+    var opmlRequest = request(`https://${process.env.PROJECT_DOMAIN}.glitch.me/subscriptions.opml`);
+    
+    opmlRequest.on("error", function(error) {
+      // Reject the Promise by returning an error, with the origin
+      // of the error set to the request.
+      reject({ error: error });
+    });
+  
+    opmlRequest.on("response", function (response) {
+      // If we didn't get a 200 OK, emit an error.
+      if (response.statusCode != 200) reject(new Error("Bad status code"));
+      // Otherwise, pipe the request into feedparser.
+      this.pipe(opmlparser);
+    })
+
+    opmlparser.on("error", function(error) {
+      // Reject the Promise by returning an error, with the origin
+      // of the error set to the request.
+      reject({ error: error });
+    });
+  
+    opmlparser.on("readable", function () {
+      let outline;
+
+      while (outline = this.read()) {
+        if (outline['#type'] === "feed") {
+          counter++;
+          feedUrls.push(outline.xmlurl);
+        }
+      }
+    });
+    opmlparser.on("end", function () {
+      resolve(feedUrls);
+    });
+  });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "express": "^4.17.1",
     "sqlite3": "^4.1.1",
-    "feedparser": "^2.2.9"
+    "feedparser": "^2.2.9",
+    "opmlparser": "^0.8.0"
   },
   "engines": {
     "node": "12.x"

--- a/public/subscriptions.opml
+++ b/public/subscriptions.opml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<opml version="2.0">
+	<head>
+		<title>subscriptions.opml</title>
+		<dateCreated>Tue, 28 Apr 2020 13:56:00 GMT</dateCreated>
+		<dateModified>Tue, 28 Apr 2020 13:56:00 GMT</dateModified>
+		<ownerName>Glitch</ownerName>
+  </head>
+	<body>
+    <outline text="Glitch on Dev.to" description="Posts by the Glitch team on Dev.to" htmlUrl="https://dev.to/glitch/" language="unknown" title="Glitch on Dev.to" type="rss" version="RSS2" xmlUrl="https://dev.to/feed/glitch/"/>
+		<outline text="Angelo on Dev.to" description="Posts by Angelo Stavrow on Dev.to" htmlUrl="https://dev.to/angelostavrow/" language="unknown" title="Angelo on Dev.to" type="rss" version="RSS2" xmlUrl="https://dev.to/feed/angelostavrow/"/>
+  </body>
+</opml>

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@
 const express = require("express");
 const bodyParser = require("body-parser");
 const feedparser = require("./feedparser");
+const opmlparser = require("./opmlparser");
 const app = express();
 const fs = require("fs");
 app.use(bodyParser.urlencoded({ extended: true }));
@@ -49,6 +50,22 @@ db.serialize(() => {
 // http://expressjs.com/en/starter/basic-routing.html
 app.get("/", (request, response) => {
   response.sendFile(`${__dirname}/views/index.html`);
+});
+
+app.get("/opml", async function(request, response) {
+  opmlparser.getFeedsFromOPML().then(data => {
+    const feeds = [];
+    data.forEach((feed, index) => {
+      feedparser.parse(feed).then(items => {
+        feeds.push(items);
+        if (index === data.length - 1) { response.send(feeds); }
+      }).catch(error => {
+        response.send({ error: error });
+      });
+    });
+  }).catch(error => {
+    response.send({ error: error });
+  });
 });
 
 // API endpoint to parse an RSS/Atom feed.

--- a/server.js
+++ b/server.js
@@ -52,12 +52,20 @@ app.get("/", (request, response) => {
   response.sendFile(`${__dirname}/views/index.html`);
 });
 
+// A test endpoint for parsing the OPML file in the public directory.
 app.get("/opml", async function(request, response) {
+  // Call the `getFeedsFromOPML` method in opmlparser.js
   opmlparser.getFeedsFromOPML().then(data => {
     const feeds = [];
+    
+    // For each feed we find in the OPML file, send it to the
+    // feed parser and add the response to the `feeds` array.
+    // If there are any errors, send them back to the client.
     data.forEach((feed, index) => {
       feedparser.parse(feed).then(items => {
         feeds.push(items);
+        // When we get to the last feed, send the whole feed
+        // array back to the client.
         if (index === data.length - 1) { response.send(feeds); }
       }).catch(error => {
         response.send({ error: error });

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -1,6 +1,7 @@
 dependencies:
   express: 4.17.1
   feedparser: 2.2.9
+  opmlparser: 0.8.0
   sqlite3: 4.1.1
 packages:
   /abbrev/1.1.1:
@@ -531,6 +532,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+  /isarray/0.0.1:
+    dev: false
+    resolution:
+      integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
   /isarray/1.0.0:
     dev: false
     resolution:
@@ -772,6 +777,15 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  /opmlparser/0.8.0:
+    dependencies:
+      readable-stream: 1.1.14
+      sax: 0.6.1
+    dev: false
+    engines:
+      node: '>= 0.8.0'
+    resolution:
+      integrity: sha1-pddINLE2r5pjkBP13Dl0a3wnBj8=
   /os-homedir/1.0.2:
     dev: false
     engines:
@@ -877,6 +891,15 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  /readable-stream/1.1.14:
+    dependencies:
+      core-util-is: 1.0.2
+      inherits: 2.0.4
+      isarray: 0.0.1
+      string_decoder: 0.10.31
+    dev: false
+    resolution:
+      integrity: sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
   /readable-stream/2.3.7:
     dependencies:
       core-util-is: 1.0.2
@@ -935,6 +958,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+  /sax/0.6.1:
+    dev: false
+    resolution:
+      integrity: sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk=
   /sax/1.2.4:
     dev: false
     resolution:
@@ -1038,6 +1065,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  /string_decoder/0.10.31:
+    dev: false
+    resolution:
+      integrity: sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
   /string_decoder/1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -1177,4 +1208,5 @@ shrinkwrapVersion: 3
 specifiers:
   express: ^4.17.1
   feedparser: ^2.2.9
+  opmlparser: ^0.8.0
   sqlite3: ^4.1.1


### PR DESCRIPTION
This PR adds an `/opml` endpoint in **server.js** which uses **opmlparser.js** to:

1. parse the OPML file at `public/subscriptions.opml`;
2. send each feed URL to the `/api/parse/:feed` endpoints; and
3. return the JSON all feeds to the client.

You can test this by going to https://rss-firehose-parseopml.glitch.me/opml and checking out the returned JSON for the Glitch feed from Dev.to and my own feed on Dev.to — it's helpful to have a JSON viewer extension installed in your browser (Firefox Developer Edition handles JSON nicely by default).